### PR TITLE
Multi threading

### DIFF
--- a/IoMonitor/include/ioMap.hh
+++ b/IoMonitor/include/ioMap.hh
@@ -123,12 +123,12 @@ class IoMap {
 		//--------------------------------------------
 		/// Constructor by copy constructor
 		//--------------------------------------------
-		IoMap(const IoMap &other);
+		IoMap(const IoMap &other) = delete;
 
 		//--------------------------------------------
 		/// Overload the operator =
 		//--------------------------------------------
-		IoMap& operator=(const IoMap &other);
+		IoMap& operator=(const IoMap &other) = delete;
 
 		static std::mutex _osMutex;
 
@@ -206,10 +206,15 @@ class IoMap {
 
 		//--------------------------------------------
 		/// @brief Overload operator << to print
-		/// the entire multimap
+		/// the entire multimap from a IoMap object
 		//--------------------------------------------
 		friend std::ostream& operator<<(std::ostream &os, const IoMap &other);
 
+		//--------------------------------------------
+		/// @brief Overload operator << to print
+		/// the entire multimap
+		//--------------------------------------------
+		friend std::ostream& operator<<(std::ostream &os, const std::unordered_multimap<uint64_t, std::shared_ptr<IoStat> > &other);
 
 		//--------------------------------------------
 		/// Template
@@ -302,6 +307,7 @@ class IoMap {
 		if (stdDivisor > 0)
 			weighted.second = std::sqrt(weighted.second / stdDivisor);
 
+		// std::cout << "test: " << weighted.first << "/" << weighted.second << std::endl;
 		return weighted;
 	}
 };

--- a/IoMonitor/include/ioMap.hh
+++ b/IoMonitor/include/ioMap.hh
@@ -208,7 +208,7 @@ class IoMap {
 		/// @brief Overload operator << to print
 		/// the entire multimap
 		//--------------------------------------------
-		friend std::ostream& operator<<(std::ostream &os, const IoMap *other);
+		friend std::ostream& operator<<(std::ostream &os, const IoMap &other);
 
 
 		//--------------------------------------------

--- a/IoMonitor/include/ioMap.hh
+++ b/IoMonitor/include/ioMap.hh
@@ -37,6 +37,11 @@
 //--------------------------------------------
 #define IOMAP_NAME "IoMap"
 
+//--------------------------------------------
+/// the time the cleanloop function must wait
+/// before cleaning the map
+//--------------------------------------------
+#define TIME_TO_CLEAN 60
 
 class IoMap {
 	private:
@@ -49,6 +54,28 @@ class IoMap {
 		/// inactive I/Os every 60 seconds and removes them
 		//--------------------------------------------
 		void cleanerLoop();
+
+		//--------------------------------------------
+		/// @brief Displays the string given as a parameter
+		/// in a format corresponding to the class with the
+		/// current timestamp
+		///
+		/// @param	os The output stream
+		/// @param	msg The message to display
+		/// - Exemple: std::cout/std::cerr
+		//--------------------------------------------
+		void	printInfo(std::ostream &os, const char *);
+
+		//--------------------------------------------
+		/// @brief Displays the string given as a parameter
+		/// in a format corresponding to the class with the
+		/// current timestamp
+		///
+		/// @param	os The output stream
+		/// @param	msg The message to display
+		/// - Exemple: std::cout/std::cerr
+		//--------------------------------------------
+		void	printInfo(std::ostream &os, const std::string &);
 
 		//--------------------------------------------
 		/// Main variable that keeps track of all IoStats
@@ -103,6 +130,7 @@ class IoMap {
 		//--------------------------------------------
 		IoMap& operator=(const IoMap &other);
 
+		static std::mutex _osMutex;
 
 		//--------------------------------------------
 		/// @brief Optional constructor
@@ -148,7 +176,7 @@ class IoMap {
 		/// @return std::vector<std::string> Vector of
 		/// all current active apps
 		//--------------------------------------------
-		std::vector<std::string> getApps();
+		std::vector<std::string> getApps() const;
 
 		//--------------------------------------------
 		///@brief Get all uids
@@ -156,7 +184,7 @@ class IoMap {
 		/// @return std::vector<uid_t> Vector of
 		/// all current active uids
 		//--------------------------------------------
-		std::vector<uid_t> getUids();
+		std::vector<uid_t> getUids() const;
 
 		//--------------------------------------------
 		///@brief Get all gids
@@ -164,7 +192,7 @@ class IoMap {
 		/// @return std::vector<uid_t> Vector of
 		/// all current active gids
 		//--------------------------------------------
-		std::vector<gid_t> getGids();
+		std::vector<gid_t> getGids() const;
 		
 
 		//--------------------------------------------
@@ -175,30 +203,6 @@ class IoMap {
 		/// all current active gids
 		//--------------------------------------------
 		std::unordered_multimap<uint64_t, std::shared_ptr<IoStat> > GetAllStatsSnapshot() const;
-
-		//--------------------------------------------
-		/// Static function
-		/// @brief Displays the string given as a parameter
-		/// in a format corresponding to the class with the
-		/// current timestamp
-		///
-		/// @param	os The output stream
-		/// @param	msg The message to display
-		/// - Exemple: std::cout/std::cerr
-		//--------------------------------------------
-		static void	printInfo(std::ostream &os, const char *);
-
-		//--------------------------------------------
-		/// Static function
-		/// @brief Displays the string given as a parameter
-		/// in a format corresponding to the class with the
-		/// current timestamp
-		///
-		/// @param	os The output stream
-		/// @param	msg The message to display
-		/// - Exemple: std::cout/std::cerr
-		//--------------------------------------------
-		static void	printInfo(std::ostream &os, const std::string &);
 
 		//--------------------------------------------
 		/// @brief Overload operator << to print

--- a/IoMonitor/include/ioMap.hh
+++ b/IoMonitor/include/ioMap.hh
@@ -41,7 +41,7 @@
 /// the time the cleanloop function must wait
 /// before cleaning the map
 //--------------------------------------------
-#define TIME_TO_CLEAN 15
+#define TIME_TO_CLEAN 60
 
 class IoMap {
 	private:

--- a/IoMonitor/include/ioMap.hh
+++ b/IoMonitor/include/ioMap.hh
@@ -41,7 +41,7 @@
 /// the time the cleanloop function must wait
 /// before cleaning the map
 //--------------------------------------------
-#define TIME_TO_CLEAN 60
+#define TIME_TO_CLEAN 15
 
 class IoMap {
 	private:
@@ -121,16 +121,14 @@ class IoMap {
 		~IoMap();
 
 		//--------------------------------------------
-		/// Constructor by copy constructor
+		/// Explicite block constructor by copy constructor
 		//--------------------------------------------
 		IoMap(const IoMap &other) = delete;
 
 		//--------------------------------------------
-		/// Overload the operator =
+		/// Explicite block overload the operator =
 		//--------------------------------------------
 		IoMap& operator=(const IoMap &other) = delete;
-
-		static std::mutex _osMutex;
 
 		//--------------------------------------------
 		/// @brief Optional constructor
@@ -144,6 +142,10 @@ class IoMap {
 		//--------------------------------------------
 		IoMap(int);
 
+		//--------------------------------------------
+		/// Public static mutex to share outputs stream
+		//--------------------------------------------
+		static std::mutex _osMutex;
 		
 		//--------------------------------------------
 		/// @brief adds an IoStat object to the multimap

--- a/IoMonitor/include/ioMonitor.hh
+++ b/IoMonitor/include/ioMonitor.hh
@@ -86,7 +86,7 @@ const char*	getCurrentTime();
 /// the corresponding class will be displayed
 //--------------------------------------------
 namespace config {
-	constexpr bool IoStatDebug = true;
-	constexpr bool IoMapDebug = false;
+	constexpr bool IoStatDebug = false;
+	constexpr bool IoMapDebug = true;
 	constexpr bool IoMarkDebug = false;
 }

--- a/IoMonitor/include/ioMonitor.hh
+++ b/IoMonitor/include/ioMonitor.hh
@@ -87,6 +87,6 @@ const char*	getCurrentTime();
 //--------------------------------------------
 namespace config {
 	constexpr bool IoStatDebug = false;
-	constexpr bool IoMapDebug = true;
+	constexpr bool IoMapDebug = false;
 	constexpr bool IoMarkDebug = false;
 }

--- a/IoMonitor/src/ioMap.cc
+++ b/IoMonitor/src/ioMap.cc
@@ -205,8 +205,8 @@ std::unordered_multimap<uint64_t, std::shared_ptr<IoStat> > IoMap::GetAllStatsSn
 //--------------------------------------------
 /// Overload operator << to print the entire multimap
 //--------------------------------------------
-std::ostream& operator<<(std::ostream &os, const IoMap *other){
-	for (auto it : other->_filesMap){
+std::ostream& operator<<(std::ostream &os, const IoMap &other){
+	for (auto it : other._filesMap){
 		os << C_GREEN << "┌─[" << C_CYAN << "IoMap" << C_GREEN << "]" << C_RESET;
 		os << C_GREEN << "[" << C_CYAN << "id:" << it.first << C_GREEN << "]" << C_RESET;
 		os << C_GREEN << "[" <<  C_CYAN << "app:"<< it.second->getApp() << C_GREEN << "]" << C_RESET;

--- a/IoMonitor/src/ioMap.cc
+++ b/IoMonitor/src/ioMap.cc
@@ -13,9 +13,11 @@ IoMap::IoMap() : _running(true){
 /// Destructor
 //--------------------------------------------
 IoMap::~IoMap() {
-	std::lock_guard<std::mutex> lock(_mutex);
-	_running = false;
-	_cv.notify_one();
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		_running = false;
+		_cv.notify_one();
+	}
 	if (_cleaner.joinable()){
 		_cleaner.join();
 	}

--- a/IoMonitor/src/ioStat.cc
+++ b/IoMonitor/src/ioStat.cc
@@ -188,12 +188,16 @@ std::pair<double, double> IoStat::bandWidth(Marks enumMark, size_t *range, size_
 	// Calcule average
 	for (std::deque<IoMark>::const_iterator it = begin; it < end; it++)
 		avrg += static_cast<double>(it->bytes);
-	avrg = avrg / std::distance(begin, end);
+	if (std::distance(begin, end) > 0)
+		avrg = avrg / std::distance(begin, end);
 
 	// Calcule standard deviation
-	for (std::deque<IoMark>::const_iterator it = begin; it < end; it++)
-		deviation += std::pow(static_cast<double>(it->bytes - avrg), 2);
-	deviation = std::sqrt(deviation / (std::distance(begin, end) - 1));
+	if (std::distance(begin, end) > 1){
+		for (std::deque<IoMark>::const_iterator it = begin; it < end; it++){
+			deviation += std::pow(std::abs(it->bytes - avrg), 2);
+		}
+		deviation = std::sqrt(deviation / (std::distance(begin, end) - 1));
+	}
 
 	return (std::pair<double, double>(avrg, deviation));
 }
@@ -231,7 +235,7 @@ ssize_t IoStat::getSize(Marks enumMark) const{
 std::ostream& operator<<(std::ostream &os, const IoStat *other){
 	std::pair<double, double> read = other->bandWidth(IoStat::Marks::READ, NULL);
 	std::pair<double, double> write = other->bandWidth(IoStat::Marks::WRITE, NULL);
-	os << "[ IoStat bandwodth from last 10s] " << std::endl;
+	os << "[IoStat bandwodth from last 10s] " << std::endl;
 	os << C_BLUE << "[READ]{average: " << read.first <<
 		", standard deviation: " << read.second <<  "}";
 	os << " / ";

--- a/IoMonitor/tests/testIoMap.cc
+++ b/IoMonitor/tests/testIoMap.cc
@@ -1,50 +1,24 @@
 #include "tester.hh"
 
 void fillData(IoMap *map){
-	map->AddRead(42, "mgm", 4, 2, 1);
-	map->AddRead(42, "mgm", 4, 2, 532);
-	map->AddRead(42, "mgm", 4, 2, 241);
-	map->AddRead(42, "mgm", 4, 2, 421);
-	map->AddRead(42, "mgm", 4, 2, 721);
-
-	map->AddRead(42, "mgm", 4, 4, 9042);
-	map->AddRead(42, "mgm", 4, 4, 9042);
-	map->AddRead(42, "mgm", 4, 4, 4290);
-	map->AddRead(42, "mgm", 4, 4, 5450);
-	map->AddRead(42, "mgm", 4, 4, 540);
-
-	map->AddRead(42, "mgm", 4, 44, 852);
-	map->AddRead(42, "mgm", 4, 44, 425);
-	map->AddRead(42, "mgm", 4, 44, 312);
-
-	map->AddRead(42, "mgm", 4752, 2342, 70);
-	map->AddRead(42, "mgm", 4752, 2342, 7244);
-
-	map->AddRead(42, "pdf", 4, 2, 6340);
-	map->AddRead(42, "pdf", 4, 2, 5);
-
-	map->AddRead(42, "pdf", 10, 2, 100);
-	map->AddRead(42, "pdf", 10, 2, 200);
-	map->AddRead(42, "pdf", 10, 2, 654);
-	map->AddRead(42, "pdf", 10, 2, 245);
-	map->AddRead(42, "pdf", 10, 2, 182);
-
-	map->AddRead(42, "pdf", 10, 500, 400);
-	map->AddRead(42, "pdf", 10, 500, 500);
-
-	map->AddRead(42, "pdf", 4, 1, 6340);
-
-	map->AddRead(24, "pdf", 10, 2, 100);
-	map->AddRead(24, "pdf", 10, 2, 200);
-	map->AddRead(24, "pdf", 10, 2, 654);
-	map->AddRead(24, "pdf", 10, 2, 245);
-	map->AddRead(24, "pdf", 10, 2, 182);
-
-	map->AddRead(50, "pdf", 10, 2, 424);
-	map->AddRead(50, "pdf", 10, 2, 28355);
-	map->AddRead(50, "pdf", 52, 2, 325);
-	map->AddRead(50, "pdf", 52, 2, 985);
-	map->AddRead(50, "pdf", 52, 2, 4562);
+	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
+		int uid = std::abs(rand() % 100);
+		int gid = std::abs(rand() % 100);
+		size_t bytes = std::abs(rand() % 100000);
+		map->AddRead(1, "mgm", uid, gid, bytes);
+	}
+	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
+		int uid = std::abs(rand() % 100);
+		int gid = std::abs(rand() % 100);
+		size_t bytes = std::abs(rand() % 100000);
+		map->AddRead(1, "pdf", uid, gid, bytes);
+	}
+	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
+		int uid = std::abs(rand() % 100);
+		int gid = std::abs(rand() % 100);
+		size_t bytes = std::abs(rand() % 100000);
+		map->AddRead(1, "eos", uid, gid, bytes);
+	}
 }
 
 void fillGroup1(IoMap *map){
@@ -72,10 +46,34 @@ void fillGroup3(IoMap *map){
 }
 
 int testIoMap(){
+	IoMap map;
+
+	fillData(&map);
+	std::cout << map;
+	// std::this_thread::sleep_for(std::chrono::seconds(2));
+	// std::vector<std::optional<std::pair<double, double> > > data;
+	//
+	// fillData(&map);
+	// data.push_back(map.getBandwidth("mgm", IoStat::Marks::READ, 3));
+	// data.push_back(map.getBandwidth("pdf", IoStat::Marks::READ, 3));
+	// data.push_back(map.getBandwidth<uid_t>(10, IoStat::Marks::READ, 3));
+	// data.push_back(map.getBandwidth<gid_t>(2, IoStat::Marks::READ, 3));
+	// for (auto it : data){
+	// 	if (it.has_value())
+	// 		std::cout << "avrg: " << it->first << " | standard deviation: " << it->second << std::endl;
+	// 	else
+	// 		std::cout << "no value" << std::endl;
+	// 	// std::this_thread::sleep_for(std::chrono::seconds(5));
+	// }
+	return 0;
+}
+
+int testInteractiveIoMap(){
 	IoMap *map = new IoMap();
 
 	while(true){
 		std::lock_guard<std::mutex> lock(IoMap::_osMutex);
+		std::cout << "ran: " << rand() << std::endl;
 		std::string input;
 		std::cout << "[IoMap]-> ";
 		std::getline(std::cin, input);
@@ -132,19 +130,5 @@ int testIoMap(){
 		std::cout << std::endl;
 	}
 	delete map;
-	// std::this_thread::sleep_for(std::chrono::seconds(2));
-	// std::vector<std::optional<std::pair<double, double> > > data;
-	//
-	// data->push_back(map->getBandwidth("mgm", IoStat::Marks::READ, 3));
-	// data->push_back(map->getBandwidth("pdf", IoStat::Marks::READ, 3));
-	// data->push_back(map->getBandwidth<uid_t>(10, IoStat::Marks::READ, 3));
-	// data->push_back(map->getBandwidth<gid_t>(2, IoStat::Marks::READ, 3));
-	// for (auto it : data){
-	// 	if (it->has_value())
-	// 		std::cout << "avrg: " << it->first << " | standard deviation: " << it->second << std::endl;
-	// 	else
-	// 		std::cout << "no value" << std::endl;
-	// 	// std::this_thread::sleep_for(std::chrono::seconds(5));
-	// }
 	return 0;
 }

--- a/IoMonitor/tests/testIoMap.cc
+++ b/IoMonitor/tests/testIoMap.cc
@@ -2,22 +2,31 @@
 
 void fillData(IoMap *map){
 	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
-		int uid = std::abs(rand() % 100);
-		int gid = std::abs(rand() % 100);
-		size_t bytes = std::abs(rand() % 100000);
-		map->AddRead(1, "mgm", uid, gid, bytes);
+		int uid = std::abs(rand() % 4);
+		int gid = std::abs(rand() % 4);
+		for (size_t it = 0, max = std::abs(rand() % 100); it < max;it++){
+			size_t bytes = std::abs(rand() % 100000);
+			map->AddRead(1, "mgm", uid, gid, bytes);
+			map->AddWrite(1, "mgm", uid, gid, bytes * 2);
+		}
 	}
 	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
-		int uid = std::abs(rand() % 100);
-		int gid = std::abs(rand() % 100);
-		size_t bytes = std::abs(rand() % 100000);
-		map->AddRead(1, "pdf", uid, gid, bytes);
+		int uid = std::abs(rand() % 4);
+		int gid = std::abs(rand() % 4);
+		for (size_t it = 0, max = std::abs(rand() % 100); it < max;it++){
+			size_t bytes = std::abs(rand() % 100000);
+			map->AddRead(1, "fdf", uid, gid, bytes);
+			map->AddWrite(1, "fdf", uid, gid, bytes * 2);
+		}
 	}
 	for (size_t i = 0, j = std::abs(rand() % 10); i < j; i++){
-		int uid = std::abs(rand() % 100);
-		int gid = std::abs(rand() % 100);
-		size_t bytes = std::abs(rand() % 100000);
-		map->AddRead(1, "eos", uid, gid, bytes);
+		int uid = std::abs(rand() % 4);
+		int gid = std::abs(rand() % 4);
+		for (size_t it = 0, max = std::abs(rand() % 100); it < max;it++){
+			size_t bytes = std::abs(rand() % 100000);
+			map->AddRead(1, "miniRT", uid, gid, bytes);
+			map->AddWrite(1, "miniRT", uid, gid, bytes * 2);
+		}
 	}
 }
 
@@ -45,90 +54,156 @@ void fillGroup3(IoMap *map){
 	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
 }
 
-int testIoMap(){
-	IoMap map;
+void prompt(bool &isMultiT, std::string &input){
+	while (true){
+		if (isMultiT)
+			std::cout << "[MultiThreading][IoMap]-> ";
+		else
+			std::cout << "[SingleThread][IoMap]-> ";
+		std::getline(std::cin, input);
+		if (input.empty())
+			continue;
+		break;
+	}
+}
 
-	fillData(&map);
-	std::cout << map;
-	// std::this_thread::sleep_for(std::chrono::seconds(2));
-	// std::vector<std::optional<std::pair<double, double> > > data;
-	//
-	// fillData(&map);
-	// data.push_back(map.getBandwidth("mgm", IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth("pdf", IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth<uid_t>(10, IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth<gid_t>(2, IoStat::Marks::READ, 3));
-	// for (auto it : data){
-	// 	if (it.has_value())
-	// 		std::cout << "avrg: " << it->first << " | standard deviation: " << it->second << std::endl;
-	// 	else
-	// 		std::cout << "no value" << std::endl;
-	// 	// std::this_thread::sleep_for(std::chrono::seconds(5));
-	// }
+void print(IoMap *map){
+	auto snap = map->GetAllStatsSnapshot();
+	for (auto it : snap){
+		std::cout << C_GREEN << "┌─[" << C_CYAN << "IoMap" << C_GREEN << "]" << C_RESET;
+		std::cout << C_GREEN << "[" << C_CYAN << "id:" << it.first << C_GREEN << "]" << C_RESET;
+		std::cout << C_GREEN << "[" <<  C_CYAN << "app:"<< it.second->getApp() << C_GREEN << "]" << C_RESET;
+		std::cout << C_GREEN << "[" << C_CYAN << "uid:" << it.second->getUid() << C_GREEN << "]" << C_RESET;
+		std::cout << C_GREEN << "[" << C_CYAN << "gid:" << it.second->getGid() << C_GREEN << "]" << C_RESET;
+		std::cout << C_GREEN << "[" << C_CYAN << "sR:" << it.second->getSize(IoStat::Marks::READ)
+			<< "/sW:"<< it.second->getSize(IoStat::Marks::WRITE) << C_GREEN << "]" << C_RESET;
+		std::cout << std::endl << C_GREEN << "└─[" << C_CYAN << "IoStat" << C_GREEN << "]" << C_RESET;
+		std::cout << std::fixed << std::setprecision(3) << C_WHITE << it.second << C_RESET << std::endl;
+	}
+}
+
+void fill(IoMap *map, std::stringstream &os){
+	std::string cmd;
+	os >> cmd;
+	if (cmd.empty()){
+		fillData(map);
+		std::cout << "fillData" << std::endl;
+	}
+	else if (cmd == "1")
+		fillGroup1(map);
+	else if (cmd == "2")
+		fillGroup2(map);
+	else if (cmd == "3")
+		fillGroup3(map);
+	else
+		std::cerr << "IoMap: " << "fill: @params[1, 2 , 3, NULL]" << std::endl;
+}
+
+void purge(bool &isMultiT, IoMap *map){
+	if (map){
+		delete map;
+		if (isMultiT)
+			map = new IoMap();
+		else
+			map = new IoMap(0);
+	}
+}
+
+int set(IoMap *map, std::stringstream &os){
+	std::string params;
+	(void)params;
+	(void)map;
+	(void)os;
+	return 0;
+}
+
+int execCmd(std::string &input, IoMap *map, bool &isMultiT){
+	std::stringstream os(input);
+	std::string cmd;
+	os >> cmd;
+	if (cmd == "exit"){
+		std::cout << "exit" << std::endl;
+		return 1;
+	}
+	else if (cmd == "print" || cmd == "p")
+		print(map);
+	else if (cmd == "fill")
+		fill(map, os);
+	else if (cmd == "clear" || cmd == "c")
+		std::cout << "\033c";
+	else if (cmd == "purge")
+		purge(isMultiT, map);
+	else if (cmd == "set")
+			set(map, os);
+	else
+		std::cerr << "IoMap: " << input << " :command not found" << std::endl;
+	if (cmd != "clear" && cmd != "c")
+		std::cout << std::endl;
 	return 0;
 }
 
 int testInteractiveIoMap(){
-	IoMap *map = new IoMap();
+	IoMap *map;
+	bool isMultiT = false;
 
-	while(true){
+	while (true){
 		std::lock_guard<std::mutex> lock(IoMap::_osMutex);
-		std::cout << "ran: " << rand() << std::endl;
-		std::string input;
-		std::cout << "[IoMap]-> ";
-		std::getline(std::cin, input);
-		if (input.empty())
+		std::string tmp;
+		std::cout << "run multithreading? [y/n]: ";
+		std::getline(std::cin, tmp);
+		if (tmp != "y" && tmp != "n")
 			continue;
-		std::stringstream os(input);
-		std::string cmd;
-		os >> cmd;
-		if (cmd == "exit"){
-			std::cout << "exit" << std::endl;
-			break;
-		}
-		else if (cmd == "print" || cmd == "p"){
-			auto snap = map->GetAllStatsSnapshot();
-			for (auto it : snap){
-				std::cout << C_GREEN << "┌─[" << C_CYAN << "IoMap" << C_GREEN << "]" << C_RESET;
-				std::cout << C_GREEN << "[" << C_CYAN << "id:" << it.first << C_GREEN << "]" << C_RESET;
-				std::cout << C_GREEN << "[" <<  C_CYAN << "app:"<< it.second->getApp() << C_GREEN << "]" << C_RESET;
-				std::cout << C_GREEN << "[" << C_CYAN << "uid:" << it.second->getUid() << C_GREEN << "]" << C_RESET;
-				std::cout << C_GREEN << "[" << C_CYAN << "gid:" << it.second->getGid() << C_GREEN << "]" << C_RESET;
-				std::cout << C_GREEN << "[" << C_CYAN << "sR:" << it.second->getSize(IoStat::Marks::READ)
-					<< "/sW:"<< it.second->getSize(IoStat::Marks::WRITE) << C_GREEN << "]" << C_RESET;
-				std::cout << std::endl << C_GREEN << "└─[" << C_CYAN << "IoStat" << C_GREEN << "]" << C_RESET;
-				std::cout << std::fixed << std::setprecision(3) << C_WHITE << it.second << C_RESET << std::endl;
-			}
-		}
-		else if (cmd == "fill"){
-			std::cout << "fill data begin!" << std::endl;
-
-			cmd.clear();
-			os >> cmd;
-			if (cmd.empty()){
-				fillData(map);
-				std::cout << "full fill" << std::endl;
-			}
-			else if (cmd == "-g" && os >> cmd){
-				if (cmd == "1")
-					fillGroup1(map);
-				else if (cmd == "2")
-					fillGroup2(map);
-				else if (cmd == "3")
-					fillGroup3(map);
-				else
-					std::cerr << "IoMap: " << cmd << " :group not found" << std::endl;
-			}
-			else
-				std::cerr << "IoMap: " << input << " : Need group id [1, 2, 3]" << std::endl;
-			std::cout << "fill data end" << std::endl;
-		}
-		else if (cmd == "clear" || cmd == "c")
-			std::cout << "\033c";
+		tmp == "y" ? isMultiT = true : isMultiT = false;
+		if (isMultiT)
+			map = new IoMap();
 		else
-			std::cerr << "IoMap: " << input << " :command not found" << std::endl;
-		std::cout << std::endl;
+			map = new IoMap(0);
+		std::cout << "\033c";
+		break;
+	}
+	while(true){
+		std::unique_lock<std::mutex> lock(IoMap::_osMutex);
+		std::string input;
+		if (isMultiT)
+			lock.unlock();
+		prompt(isMultiT, input);
+		if (execCmd(input, map, isMultiT) == 1)
+			break ;
 	}
 	delete map;
+	return 0;
+}
+
+int testIoMap(){
+	std::multimap<std::string, std::optional<std::pair<double, double> > > data;
+	std::vector<IoMap*> maps;
+	size_t nbrOfMap = 3;
+
+	for (size_t i = 0; i < nbrOfMap; i++)
+		maps.push_back(new IoMap());
+	for (size_t i = 0; i < nbrOfMap; i++)
+		fillData(maps.at(i));
+
+	for (size_t i = 0; i < 5; i++){
+		std::lock_guard<std::mutex> lock(IoMap::_osMutex);
+
+		for (auto &it : maps){
+			data.insert({"mgm", it->getBandwidth("mgm", IoStat::Marks::READ, 2)});
+			data.insert({"mgm", it->getBandwidth("mgm", IoStat::Marks::WRITE, 2)});
+			data.insert({"uid_t: 2", it->getBandwidth<uid_t>(2, IoStat::Marks::READ)});
+			data.insert({"uid_t: 2", it->getBandwidth<uid_t>(2, IoStat::Marks::WRITE)});
+			data.insert({"gid_t: 1", it->getBandwidth<gid_t>(1, IoStat::Marks::READ)});
+			data.insert({"gid_t: 1", it->getBandwidth<gid_t>(1, IoStat::Marks::WRITE)});
+			for (auto &it : data){
+				if (it.second.has_value()){
+					std::cout << "map[" << it.first << "]: "
+						<< "avrg: " << it.second->first << " | standard deviation: " << it.second->second << std::endl;
+				}
+				else
+					std::cout << "no value" << std::endl;
+			}
+		}
+		std::this_thread::sleep_for(std::chrono::seconds(2));
+	}
 	return 0;
 }

--- a/IoMonitor/tests/testIoMap.cc
+++ b/IoMonitor/tests/testIoMap.cc
@@ -194,16 +194,22 @@ int testIoMap(){
 			data.insert({"uid_t: 2", it->getBandwidth<uid_t>(2, IoStat::Marks::WRITE)});
 			data.insert({"gid_t: 1", it->getBandwidth<gid_t>(1, IoStat::Marks::READ)});
 			data.insert({"gid_t: 1", it->getBandwidth<gid_t>(1, IoStat::Marks::WRITE)});
-			for (auto &it : data){
-				if (it.second.has_value()){
-					std::cout << "map[" << it.first << "]: "
-						<< "avrg: " << it.second->first << " | standard deviation: " << it.second->second << std::endl;
+			if (config::IoMapDebug){
+				for (auto &it : data){
+					if (it.second.has_value()){
+						std::cout << "map[" << it.first << "]: "
+							<< "avrg: " << it.second->first << " | standard deviation: " << it.second->second << std::endl;
+					}
+					else
+						std::cout << "no value" << std::endl;
 				}
-				else
-					std::cout << "no value" << std::endl;
+				std::cout << std::endl;
 			}
 		}
-		std::this_thread::sleep_for(std::chrono::seconds(2));
+		std::this_thread::sleep_for(std::chrono::seconds(1));
+	}
+	for (auto it = maps.begin(); it != maps.end(); it++){
+		delete *it;
 	}
 	return 0;
 }

--- a/IoMonitor/tests/testIoMap.cc
+++ b/IoMonitor/tests/testIoMap.cc
@@ -1,64 +1,146 @@
 #include "tester.hh"
 
+void fillData(IoMap *map){
+	map->AddRead(42, "mgm", 4, 2, 1);
+	map->AddRead(42, "mgm", 4, 2, 532);
+	map->AddRead(42, "mgm", 4, 2, 241);
+	map->AddRead(42, "mgm", 4, 2, 421);
+	map->AddRead(42, "mgm", 4, 2, 721);
+
+	map->AddRead(42, "mgm", 4, 4, 9042);
+	map->AddRead(42, "mgm", 4, 4, 9042);
+	map->AddRead(42, "mgm", 4, 4, 4290);
+	map->AddRead(42, "mgm", 4, 4, 5450);
+	map->AddRead(42, "mgm", 4, 4, 540);
+
+	map->AddRead(42, "mgm", 4, 44, 852);
+	map->AddRead(42, "mgm", 4, 44, 425);
+	map->AddRead(42, "mgm", 4, 44, 312);
+
+	map->AddRead(42, "mgm", 4752, 2342, 70);
+	map->AddRead(42, "mgm", 4752, 2342, 7244);
+
+	map->AddRead(42, "pdf", 4, 2, 6340);
+	map->AddRead(42, "pdf", 4, 2, 5);
+
+	map->AddRead(42, "pdf", 10, 2, 100);
+	map->AddRead(42, "pdf", 10, 2, 200);
+	map->AddRead(42, "pdf", 10, 2, 654);
+	map->AddRead(42, "pdf", 10, 2, 245);
+	map->AddRead(42, "pdf", 10, 2, 182);
+
+	map->AddRead(42, "pdf", 10, 500, 400);
+	map->AddRead(42, "pdf", 10, 500, 500);
+
+	map->AddRead(42, "pdf", 4, 1, 6340);
+
+	map->AddRead(24, "pdf", 10, 2, 100);
+	map->AddRead(24, "pdf", 10, 2, 200);
+	map->AddRead(24, "pdf", 10, 2, 654);
+	map->AddRead(24, "pdf", 10, 2, 245);
+	map->AddRead(24, "pdf", 10, 2, 182);
+
+	map->AddRead(50, "pdf", 10, 2, 424);
+	map->AddRead(50, "pdf", 10, 2, 28355);
+	map->AddRead(50, "pdf", 52, 2, 325);
+	map->AddRead(50, "pdf", 52, 2, 985);
+	map->AddRead(50, "pdf", 52, 2, 4562);
+}
+
+void fillGroup1(IoMap *map){
+	map->AddRead(1, "eos", 1, 1, std::abs(rand() % 100));
+	map->AddRead(1, "eos", 1, 1, std::abs(rand() % 100));
+	map->AddRead(1, "eos", 1, 1, std::abs(rand() % 100));
+	map->AddRead(1, "eos", 1, 1, std::abs(rand() % 100));
+	map->AddRead(1, "eos", 1, 1, std::abs(rand() % 100));
+}
+
+void fillGroup2(IoMap *map){
+	map->AddRead(1, "jpeg", 2, 2, std::abs(rand() % 1000));
+	map->AddRead(1, "jpeg", 2, 2, std::abs(rand() % 1000));
+	map->AddRead(1, "jpeg", 2, 2, std::abs(rand() % 1000));
+	map->AddRead(1, "jpeg", 2, 2, std::abs(rand() % 1000));
+	map->AddRead(1, "jpeg", 2, 2, std::abs(rand() % 1000));
+}
+
+void fillGroup3(IoMap *map){
+	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
+	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
+	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
+	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
+	map->AddRead(1, "jpeg", 3, 3, std::abs(rand() % 10000));
+}
+
 int testIoMap(){
-	// IoMap map(1);
-	//
-	testIoStatFillData();
-	// map.AddRead(42, "mgm", 4, 2, 1);
-	// map.AddRead(42, "mgm", 4, 2, 532);
-	// map.AddRead(42, "mgm", 4, 2, 241);
-	// map.AddRead(42, "mgm", 4, 2, 421);
-	// map.AddRead(42, "mgm", 4, 2, 721);
-	//
-	// map.AddRead(42, "mgm", 4, 4, 9042);
-	// map.AddRead(42, "mgm", 4, 4, 9042);
-	// map.AddRead(42, "mgm", 4, 4, 4290);
-	// map.AddRead(42, "mgm", 4, 4, 5450);
-	// map.AddRead(42, "mgm", 4, 4, 540);
-	//
-	// map.AddRead(42, "mgm", 4, 44, 852);
-	// map.AddRead(42, "mgm", 4, 44, 425);
-	// map.AddRead(42, "mgm", 4, 44, 312);
-	//
-	// map.AddRead(42, "mgm", 4752, 2342, 70);
-	// map.AddRead(42, "mgm", 4752, 2342, 7244);
-	//
-	// map.AddRead(42, "pdf", 4, 2, 6340);
-	// map.AddRead(42, "pdf", 4, 2, 5);
-	//
-	// map.AddRead(42, "pdf", 10, 2, 100);
-	// map.AddRead(42, "pdf", 10, 2, 200);
-	// map.AddRead(42, "pdf", 10, 2, 654);
-	// map.AddRead(42, "pdf", 10, 2, 245);
-	// map.AddRead(42, "pdf", 10, 2, 182);
-	//
-	// map.AddRead(42, "pdf", 10, 500, 400);
-	// map.AddRead(42, "pdf", 10, 500, 500);
-	//
-	// map.AddRead(42, "pdf", 4, 1, 6340);
-	//
-	// map.AddRead(24, "pdf", 10, 2, 100);
-	// map.AddRead(24, "pdf", 10, 2, 200);
-	// map.AddRead(24, "pdf", 10, 2, 654);
-	// map.AddRead(24, "pdf", 10, 2, 245);
-	// map.AddRead(24, "pdf", 10, 2, 182);
-	//
-	// map.AddRead(50, "pdf", 10, 2, 424);
-	// map.AddRead(50, "pdf", 10, 2, 28355);
-	// map.AddRead(50, "pdf", 52, 2, 325);
-	// map.AddRead(50, "pdf", 52, 2, 985);
-	// map.AddRead(50, "pdf", 52, 2, 4562);
-	//
-	//
-	// // std::this_thread::sleep_for(std::chrono::seconds(2));
+	IoMap *map = new IoMap();
+
+	while(true){
+		std::lock_guard<std::mutex> lock(IoMap::_osMutex);
+		std::string input;
+		std::cout << "[IoMap]-> ";
+		std::getline(std::cin, input);
+		if (input.empty())
+			continue;
+		std::stringstream os(input);
+		std::string cmd;
+		os >> cmd;
+		if (cmd == "exit"){
+			std::cout << "exit" << std::endl;
+			break;
+		}
+		else if (cmd == "print" || cmd == "p"){
+			auto snap = map->GetAllStatsSnapshot();
+			for (auto it : snap){
+				std::cout << C_GREEN << "┌─[" << C_CYAN << "IoMap" << C_GREEN << "]" << C_RESET;
+				std::cout << C_GREEN << "[" << C_CYAN << "id:" << it.first << C_GREEN << "]" << C_RESET;
+				std::cout << C_GREEN << "[" <<  C_CYAN << "app:"<< it.second->getApp() << C_GREEN << "]" << C_RESET;
+				std::cout << C_GREEN << "[" << C_CYAN << "uid:" << it.second->getUid() << C_GREEN << "]" << C_RESET;
+				std::cout << C_GREEN << "[" << C_CYAN << "gid:" << it.second->getGid() << C_GREEN << "]" << C_RESET;
+				std::cout << C_GREEN << "[" << C_CYAN << "sR:" << it.second->getSize(IoStat::Marks::READ)
+					<< "/sW:"<< it.second->getSize(IoStat::Marks::WRITE) << C_GREEN << "]" << C_RESET;
+				std::cout << std::endl << C_GREEN << "└─[" << C_CYAN << "IoStat" << C_GREEN << "]" << C_RESET;
+				std::cout << std::fixed << std::setprecision(3) << C_WHITE << it.second << C_RESET << std::endl;
+			}
+		}
+		else if (cmd == "fill"){
+			std::cout << "fill data begin!" << std::endl;
+
+			cmd.clear();
+			os >> cmd;
+			if (cmd.empty()){
+				fillData(map);
+				std::cout << "full fill" << std::endl;
+			}
+			else if (cmd == "-g" && os >> cmd){
+				if (cmd == "1")
+					fillGroup1(map);
+				else if (cmd == "2")
+					fillGroup2(map);
+				else if (cmd == "3")
+					fillGroup3(map);
+				else
+					std::cerr << "IoMap: " << cmd << " :group not found" << std::endl;
+			}
+			else
+				std::cerr << "IoMap: " << input << " : Need group id [1, 2, 3]" << std::endl;
+			std::cout << "fill data end" << std::endl;
+		}
+		else if (cmd == "clear" || cmd == "c")
+			std::cout << "\033c";
+		else
+			std::cerr << "IoMap: " << input << " :command not found" << std::endl;
+		std::cout << std::endl;
+	}
+	delete map;
+	// std::this_thread::sleep_for(std::chrono::seconds(2));
 	// std::vector<std::optional<std::pair<double, double> > > data;
 	//
-	// data.push_back(map.getBandwidth("mgm", IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth("pdf", IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth<uid_t>(10, IoStat::Marks::READ, 3));
-	// data.push_back(map.getBandwidth<gid_t>(2, IoStat::Marks::READ, 3));
+	// data->push_back(map->getBandwidth("mgm", IoStat::Marks::READ, 3));
+	// data->push_back(map->getBandwidth("pdf", IoStat::Marks::READ, 3));
+	// data->push_back(map->getBandwidth<uid_t>(10, IoStat::Marks::READ, 3));
+	// data->push_back(map->getBandwidth<gid_t>(2, IoStat::Marks::READ, 3));
 	// for (auto it : data){
-	// 	if (it.has_value())
+	// 	if (it->has_value())
 	// 		std::cout << "avrg: " << it->first << " | standard deviation: " << it->second << std::endl;
 	// 	else
 	// 		std::cout << "no value" << std::endl;

--- a/IoMonitor/tests/testIoStat.cc
+++ b/IoMonitor/tests/testIoStat.cc
@@ -72,7 +72,7 @@ int cleanMarks(IoStat &io, IoStat::Marks enumMark, int seconds){
 int testIoStatFillData(){
 	IoStat io(4, "mgm", 2, 2);
 
-	fillIoStat(io, 10000000, 100, 0.2);
+	fillIoStat(io, 1000000, 100, 0);
 	if (getBandWidth(io, IoStat::Marks::READ, 1) < 0
 		|| getBandWidth(io, IoStat::Marks::WRITE, 1) < 0)
 			return -1;
@@ -96,7 +96,7 @@ int testIoStatFillData(){
 
 	size = io.cleanOldsMarks(IoStat::Marks::WRITE, 0);
 	size = io.cleanOldsMarks(IoStat::Marks::READ, 0);
-	fillIoStat(io, 10000000, 100, 0.5);
+	fillIoStat(io, 1000000, 100, 0);
 	for (size_t i = 0; i < 10; i++){
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		getBandWidth(io, IoStat::Marks::WRITE, 1);
@@ -108,7 +108,7 @@ int testIoStatFillData(){
 int testIoStatCleaning(){
 	IoStat io(4, "qukdb", 2, 2);
 
-	fillIoStat(io, 10000000, 100, 0.2);
+	fillIoStat(io, 1000000, 100, 0);
 	if (cleanMarks(io, IoStat::Marks::READ, 1) < 0)
 		return -1;
 	return 0;

--- a/IoMonitor/tests/testMain.cc
+++ b/IoMonitor/tests/testMain.cc
@@ -1,21 +1,31 @@
 #include <gtest/gtest.h>
 #include "tester.hh"
 
-// TEST(IoStat, CleanData) {
-// 	EXPECT_EQ(testIoStatCleaning(), 0);
+TEST(IoStat, CleanData) {
+	EXPECT_EQ(testIoStatCleaning(), 0);
+}
+
+TEST(IoStat, FillData) {
+	EXPECT_EQ(testIoStatFillData(), 0);
+}
+
+TEST(IoMap, FillData) {
+	EXPECT_EQ(testIoMap(), 0);
+}
+
+/// Only for debugging
+// TEST(IoMap, testWithInteraction) {
+// 	EXPECT_EQ(testInteractiveIoMap(), 0);
 // }
-//
-// TEST(IoStat, FillData) {
-// 	EXPECT_EQ(testIoStatFillData(), 0);
-// }
-//
+
 int main(int ac, char **av) {
 	(void)ac;
 	(void)av;
 
 	// testIoMap();
-	testInteractiveIoMap();
+	// testInteractiveIoMap();
 	// testIoStatFillData();
+	// testIoStatCleaning();
     // ::testing::InitGoogleTest(&ac, av);
     // return RUN_ALL_TESTS();
 }

--- a/IoMonitor/tests/testMain.cc
+++ b/IoMonitor/tests/testMain.cc
@@ -13,8 +13,8 @@ int main(int ac, char **av) {
 	(void)ac;
 	(void)av;
 
-	testIoMap();
-	// testInteractiveIoMap();
+	// testIoMap();
+	testInteractiveIoMap();
 	// testIoStatFillData();
     // ::testing::InitGoogleTest(&ac, av);
     // return RUN_ALL_TESTS();

--- a/IoMonitor/tests/testMain.cc
+++ b/IoMonitor/tests/testMain.cc
@@ -14,6 +14,7 @@ int main(int ac, char **av) {
 	(void)av;
 
 	testIoMap();
+	// testInteractiveIoMap();
 	// testIoStatFillData();
     // ::testing::InitGoogleTest(&ac, av);
     // return RUN_ALL_TESTS();

--- a/IoMonitor/tests/tester.hh
+++ b/IoMonitor/tests/tester.hh
@@ -5,4 +5,5 @@
 
 int testIoStatFillData();
 int testIoStatCleaning();
+int testInteractiveIoMap();
 int testIoMap();


### PR DESCRIPTION
This pull request introduces several improvements and modifications to the `IoMonitor` module, focusing on enhancing thread safety, improving code clarity, and optimizing functionality. Key changes include the addition of a static mutex for shared stream output, the introduction of a configurable cleaning interval, and the removal of unused constructors and operators. It also refines debugging behavior and adds overloaded operators for better output formatting.

### Enhancements to Thread Safety and Multithreading
- Added a static mutex (`_osMutex`) to `IoMap` for shared output stream synchronization, improving thread safety (`IoMonitor/include/ioMap.hh`, [[1]](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fR145-R148); `IoMonitor/src/ioMap.cc`, [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5R3-R4).
- Updated `cleanerLoop` to use the new `TIME_TO_CLEAN` macro for configurable cleaning intervals and added logic to track inactive I/O more effectively (`IoMonitor/include/ioMap.hh`, [[1]](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fR40-R44); `IoMonitor/src/ioMap.cc`, [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L80-R75).

### Code Simplification and Cleanup
- Deleted unused copy constructor and assignment operator for `IoMap` to prevent accidental misuse (`IoMonitor/include/ioMap.hh`, [[1]](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fL97-R131); `IoMonitor/src/ioMap.cc`, [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5R19-R29).
- Removed redundant debug output and unused code in `AddRead` and `AddWrite` methods, reducing clutter (`IoMonitor/src/ioMap.cc`, [[1]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L108-R87) [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L117-R111).

### Debugging and Logging Improvements
- Changed `IoStatDebug` default value from `true` to `false` to disable verbose debugging by default (`IoMonitor/include/ioMonitor.hh`, [IoMonitor/include/ioMonitor.hhL89-R89](diffhunk://#diff-952488b6a099f138064c5ef935e7d3597a20767c0f37494dd13287ee519a2ecfL89-R89)).
- Refactored `printInfo` to support both `std::string` and `const char*` parameters for more flexible message formatting (`IoMonitor/include/ioMap.hh`, [IoMonitor/include/ioMap.hhR58-R79](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fR58-R79)).

### Output Formatting Enhancements
- Added overloaded `operator<<` to format and print `IoMap` and its multimap contents in a more readable way (`IoMonitor/include/ioMap.hh`, [[1]](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fL180-R219); `IoMonitor/src/ioMap.cc`, [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L199-R200).

### Optimizations and Bug Fixes
- Improved bandwidth calculation in `IoStat::bandWidth` by adding checks to avoid unnecessary computations and handle edge cases (`IoMonitor/src/ioStat.cc`, [IoMonitor/src/ioStat.ccR191-R200](diffhunk://#diff-8551afc748fd6ac5490b83862ad386ce080b44ef9e2cf9cf1279cbaa83913b30R191-R200)).
- Ensured `getApps`, `getUids`, and `getGids` methods are marked as `const` for better const-correctness (`IoMonitor/include/ioMap.hh`, [[1]](diffhunk://#diff-761e201c47da493a5309b4097c643a9712afb102435444e6081f57ebfe2a766fL151-R197); `IoMonitor/src/ioMap.cc`, [[2]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L166-R145) [[3]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L175-R154) [[4]](diffhunk://#diff-e04e49854471b45fc9ca6b31bc20f0bc9d33aabafa7dab3d712ef8c1429350e5L184-R163).